### PR TITLE
Re-define Unitful's yr (year) unit to be 365.2425 days

### DIFF
--- a/docs/src/dates.md
+++ b/docs/src/dates.md
@@ -12,7 +12,7 @@ end
 The `Dates.FixedPeriod` union type includes all `Dates.Period`s that represent a fixed period of time, i.e., `Dates.Week`, `Dates.Day`, `Dates.Hour`, `Dates.Minute`, `Dates.Second`, `Dates.Millisecond`, `Dates.Microsecond`, and `Dates.Nanosecond`. These types can be converted to `Quantity`s or used in place of them.
 
 !!! note
-    `Dates.Year` does not represent a fixed period and cannot be converted to a `Quantity`. While Unitful's `yr` unit is exactly equal to 365.25 days, a `Dates.Year` may contain 365 or 366 days.
+    `Dates.Year` does not represent a fixed period and cannot be converted to a `Quantity`. While Unitful's `yr` unit is exactly equal to 365.2425 days, a `Dates.Year` may contain 365 or 366 days (see [`Dates.isleapyear`](@ref)).
 
 Each `FixedPeriod` is considered equivalent to a `Quantity`. For example, `Dates.Millisecond(5)` corresponds to the quantity `Int64(5)*u"ms"`. A `FixedPeriod` can be converted to the equivalent `Quantity` with a constructor:
 
@@ -108,8 +108,8 @@ However, not all operations that are defined for `FixedPeriod`s support `Compoun
 The reason for that is that a `CompoundPeriod` does not correspond to a specific unit:
 
 ```@jldoctest
-julia> p = Day(365) + Hour(6)
-365 days, 6 hours
+julia> p = Day(365) + Hour(5) + Minute(49) + Second(12)
+365 days, 5 hours, 49 minutes, 12 seconds
 
 julia> unit(p)  # A CompoundPeriod does not have a corresponding unit ...
 ERROR: MethodError: no method matching unit(::Dates.CompoundPeriod)
@@ -123,7 +123,7 @@ ERROR: MethodError: no method matching Quantity(::Int64)
 [...]
 
 julia> T = typeof(1.0u"hr"); T(p)  # ... but it can be converted to a concrete time quantity
-8766.0 hr
+8765.82 hr
 ```
 
 Consequently, any operation whose result would depend on the input unit is not supported by `CompoundPeriod`s. For example:

--- a/docs/src/dates.md
+++ b/docs/src/dates.md
@@ -12,7 +12,7 @@ end
 The `Dates.FixedPeriod` union type includes all `Dates.Period`s that represent a fixed period of time, i.e., `Dates.Week`, `Dates.Day`, `Dates.Hour`, `Dates.Minute`, `Dates.Second`, `Dates.Millisecond`, `Dates.Microsecond`, and `Dates.Nanosecond`. These types can be converted to `Quantity`s or used in place of them.
 
 !!! note
-    `Dates.Year` does not represent a fixed period and cannot be converted to a `Quantity`. While Unitful's `yr` unit is exactly equal to 365.2425 days, a `Dates.Year` may contain 365 or 366 days (see [`Dates.isleapyear`](@ref)).
+    `Dates.Year` does not represent a fixed period and cannot be converted to a `Quantity`. While Unitful's `yr` unit is exactly equal to 365.2425 days, a `Dates.Year` may contain 365 or 366 days (see [`Dates.days(::Year)`](@ref) and [`Dates.isleapyear`](@ref)).
 
 Each `FixedPeriod` is considered equivalent to a `Quantity`. For example, `Dates.Millisecond(5)` corresponds to the quantity `Int64(5)*u"ms"`. A `FixedPeriod` can be converted to the equivalent `Quantity` with a constructor:
 

--- a/src/pkgdefaults.jl
+++ b/src/pkgdefaults.jl
@@ -282,10 +282,10 @@ to avoid confusion with the Julia function `min`.
 \nSee Also: [`Unitful.d`](@ref)."
 @unit wk     "wk"       Week                  604800s       false
 "    Unitful.yr
-\nThe year, a unit of time, defined as 365.25 d.
+\nThe year, a unit of time, defined as 365.2425 d.
 \nDimension: [`Unitful.𝐓`](@ref).
 \nSee Also: [`Unitful.hr`](@ref)."
-@unit yr     "yr"       Year                  31557600s     true true
+@unit yr     "yr"       Year                  31556952s     true true
 "    Unitful.rps
 \nRevolutions per second, a unit of rotational speed, defined as 2π rad / s.
 \nDimension: 𝐓^-1.

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -170,9 +170,9 @@
             @test_throws DimensionError atan(1u"m", Second(1))
 
             @test atan(CompoundPeriod(Minute(1), Second(30)), 10u"s") == atan(9,1)
-            @test atan(1u"yr", CompoundPeriod(Day(365), Hour(6))) == atan(1,1)
-            @test_throws DimensionError atan(1u"m", CompoundPeriod(Day(365), Hour(6)))
-            @test_throws DimensionError atan(CompoundPeriod(Day(365), Hour(6)), 1u"m")
+            @test atan(1u"yr", CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12))) == atan(1,1)
+            @test_throws DimensionError atan(1u"m", CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)))
+            @test_throws DimensionError atan(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)), 1u"m")
             @test_throws MethodError atan(1u"s", CompoundPeriod(Year(1)))
             @test_throws MethodError atan(CompoundPeriod(Month(6)), 1u"s")
         end
@@ -196,20 +196,20 @@
             @test uconvert(u"ns", CompoundPeriod()) === u"ns"(CompoundPeriod()) === Int64(0)u"ns"
             @test uconvert(u"ps", CompoundPeriod()) === u"ps"(CompoundPeriod()) === Int64(0)u"ps"
             @static if Sys.WORD_SIZE == 32
-                @test uconvert(u"yr", CompoundPeriod(Day(365),Hour(6))) === 1.0u"yr"
-                @test u"yr"(CompoundPeriod(Day(365),Hour(6))) === 1.0u"yr"
+                @test uconvert(u"yr", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === 1.0u"yr"
+                @test u"yr"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === 1.0u"yr"
             else
-                @test uconvert(u"yr", CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(1,1)u"yr"
-                @test u"yr"(CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(1,1)u"yr"
+                @test uconvert(u"yr", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(1,1)u"yr"
+                @test u"yr"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(1,1)u"yr"
             end
-            @test uconvert(u"μs", CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(31_557_600_000_000,1)u"μs"
-            @test u"μs"(CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(31_557_600_000_000,1)u"μs"
-            @test uconvert(u"ns", CompoundPeriod(Day(365),Hour(6))) === Int64(31_557_600_000_000_000)u"ns"
-            @test u"ns"(CompoundPeriod(Day(365),Hour(6))) === Int64(31_557_600_000_000_000)u"ns"
+            @test uconvert(u"μs", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(31_556_952_000_000,1)u"μs"
+            @test u"μs"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(31_556_952_000_000,1)u"μs"
+            @test uconvert(u"ns", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Int64(31_556_952_000_000_000)u"ns"
+            @test u"ns"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Int64(31_556_952_000_000_000)u"ns"
             @test uconvert(u"ps", CompoundPeriod(Week(1),Hour(-1))) === Int64(601_200_000_000_000_000)u"ps"
             @test u"ps"(CompoundPeriod(Week(1),Hour(-1))) === Int64(601_200_000_000_000_000)u"ps"
-            @test_throws DimensionError uconvert(u"m", CompoundPeriod(Day(365),Hour(6)))
-            @test_throws DimensionError u"m"(CompoundPeriod(Day(365),Hour(6)))
+            @test_throws DimensionError uconvert(u"m", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12)))
+            @test_throws DimensionError u"m"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12)))
             @test_throws MethodError uconvert(u"yr", CompoundPeriod(Year(1),Day(1)))
             @test_throws MethodError u"yr"(CompoundPeriod(Year(1),Day(1)))
             @test_throws MethodError uconvert(u"s", CompoundPeriod(Month(1),Day(1)))
@@ -239,14 +239,14 @@
             @test ustrip(u"ns", CompoundPeriod()) === Int64(0)
             @test ustrip(u"ps", CompoundPeriod()) === Int64(0)
             @static if Sys.WORD_SIZE == 32
-                @test ustrip(u"yr", CompoundPeriod(Day(365),Hour(6))) === 1.0
+                @test ustrip(u"yr", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === 1.0
             else
-                @test ustrip(u"yr", CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(1,1)
+                @test ustrip(u"yr", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(1,1)
             end
-            @test ustrip(u"μs", CompoundPeriod(Day(365),Hour(6))) === Rational{Int64}(31_557_600_000_000,1)
-            @test ustrip(u"ns", CompoundPeriod(Day(365),Hour(6))) === Int64(31_557_600_000_000_000)
+            @test ustrip(u"μs", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(31_556_952_000_000,1)
+            @test ustrip(u"ns", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Int64(31_556_952_000_000_000)
             @test ustrip(u"ps", CompoundPeriod(Week(1),Hour(-1))) === Int64(601_200_000_000_000_000)
-            @test_throws DimensionError ustrip(u"m", CompoundPeriod(Day(365),Hour(6)))
+            @test_throws DimensionError ustrip(u"m", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12)))
             @test_throws MethodError ustrip(CompoundPeriod())
             @test_throws MethodError ustrip(CompoundPeriod(Second(1)))
             @test_throws MethodError ustrip(CompoundPeriod(Week(1), Hour(-1)))
@@ -292,7 +292,7 @@
                      Quantity{Float64,𝐓,typeof(u"s")},
                      Quantity{Int64,𝐓,typeof(u"ns")})
                 @test T(CompoundPeriod()) === convert(T, CompoundPeriod()) === T(0u"s")
-                @test T(CompoundPeriod(Day(365), Hour(6))) === convert(T, CompoundPeriod(Day(365), Hour(6))) === T(1u"yr")
+                @test T(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12))) === convert(T, CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12))) === T(1u"yr")
                 @test T(CompoundPeriod(Week(1), Hour(-1))) === convert(T, CompoundPeriod(Week(1), Hour(-1))) === T(167u"hr")
                 @test_throws MethodError T(CompoundPeriod(Month(1)))
                 @test_throws MethodError T(CompoundPeriod(Year(1)))
@@ -301,8 +301,8 @@
             end
             @test_throws InexactError Quantity{Int64,𝐓,typeof(u"d")}(CompoundPeriod(Day(1),Hour(6)))
             @test_throws InexactError convert(typeof(1u"d"), CompoundPeriod(Day(1),Hour(1)))
-            @test_throws DimensionError Quantity{Float64,𝐋,typeof(u"m")}(CompoundPeriod(Day(365), Hour(6)))
-            @test_throws DimensionError convert(typeof(1.0u"m"), CompoundPeriod(Day(365), Hour(6)))
+            @test_throws DimensionError Quantity{Float64,𝐋,typeof(u"m")}(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)))
+            @test_throws DimensionError convert(typeof(1.0u"m"), CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)))
         end
     end
 
@@ -630,8 +630,8 @@
         @test !(Day(4) == 4u"hr")
         @test !(4u"cm" == Day(4))
 
-        @test CompoundPeriod(Day(365), Hour(6)) == 1u"yr"
-        @test 1u"yr" == CompoundPeriod(Day(365), Hour(6))
+        @test CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)) == 1u"yr"
+        @test 1u"yr" == CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12))
         @test CompoundPeriod() == -0.0u"s"
         @test !(1u"m" == CompoundPeriod(Day(1)))
         @test !(CompoundPeriod(Day(1)) == 1u"m")
@@ -647,8 +647,8 @@
         @test !isequal(Day(4), 4u"hr")
         @test !isequal(4u"cm", Day(4))
 
-        @test isequal(CompoundPeriod(Day(365), Hour(6)), 1u"yr")
-        @test isequal(1u"yr", CompoundPeriod(Day(365), Hour(6)))
+        @test isequal(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)), 1u"yr")
+        @test isequal(1u"yr", CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)))
         @test !isequal(CompoundPeriod(), -0.0u"s") # !isequal(0.0, -0.0)
         @test !isequal(1u"m", CompoundPeriod(Day(1)))
         @test !isequal(CompoundPeriod(Day(1)), 1u"m")
@@ -668,7 +668,7 @@
 
         @test CompoundPeriod(Day(365)) < 1u"yr"
         @test 1u"s" < CompoundPeriod(Second(1), Nanosecond(1))
-        @test !(CompoundPeriod(Day(365), Hour(6)) < 1u"yr")
+        @test !(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)) < 1u"yr")
         @test !(1u"s" < CompoundPeriod(Second(1)))
         @test !(-0.0u"s" < CompoundPeriod())
         @test_throws DimensionError 7u"kg" < CompoundPeriod(Day(1))
@@ -689,7 +689,7 @@
 
         @test isless(CompoundPeriod(Day(365)), 1u"yr")
         @test isless(1u"s", CompoundPeriod(Second(1), Nanosecond(1)))
-        @test !isless(CompoundPeriod(Day(365), Hour(6)), 1u"yr")
+        @test !isless(CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)), 1u"yr")
         @test !isless(1u"s", CompoundPeriod(Second(1)))
         @test isless(-0.0u"s", CompoundPeriod())
         @test_throws DimensionError isless(7u"kg", CompoundPeriod(Day(1)))
@@ -706,7 +706,7 @@
         @test_throws DimensionError 7u"kg" ≤ Day(1)
         @test_throws DimensionError Day(1) ≤ 7u"kg"
 
-        @test CompoundPeriod(Day(365), Hour(6)) ≤ 1u"yr"
+        @test CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)) ≤ 1u"yr"
         @test 1u"s" ≤ CompoundPeriod(Second(1), Nanosecond(1))
         @test !(1u"s" ≤ CompoundPeriod(Millisecond(999)))
         @test_throws DimensionError 7u"kg" ≤ CompoundPeriod(Day(1))
@@ -727,13 +727,13 @@
         @test_throws DimensionError max(Second(1), 1u"kg")
 
         @test min(1u"s", CompoundPeriod()) == CompoundPeriod()
-        @test min(1u"yr", CompoundPeriod(Day(365), Hour(7))) == 1u"yr"
+        @test min(1u"yr", CompoundPeriod(Day(365), Hour(6))) == 1u"yr"
         @test_throws DimensionError min(CompoundPeriod(), 1u"m")
         @test_throws DimensionError min(1u"m", CompoundPeriod())
         @test_throws MethodError min(1u"yr", CompoundPeriod(Year(1)))
         @test_throws MethodError min(CompoundPeriod(Month(1)), 1u"yr")
         @test max(1u"s", CompoundPeriod()) == 1u"s"
-        @test max(1u"yr", CompoundPeriod(Day(365), Hour(7))) == CompoundPeriod(Day(365), Hour(7))
+        @test max(1u"yr", CompoundPeriod(Day(365), Hour(6))) == CompoundPeriod(Day(365), Hour(6))
         @test_throws DimensionError max(CompoundPeriod(), 1u"m")
         @test_throws DimensionError max(1u"m", CompoundPeriod())
         @test_throws MethodError max(1u"yr", CompoundPeriod(Year(1)))
@@ -756,8 +756,8 @@
         @test_throws DimensionError isapprox(Second(2), 2500u"ms", atol=0.5)
         @test_throws DimensionError isapprox(Second(2), 2500u"ms", atol=0.5u"m")
 
-        @test isapprox(nextfloat(1.0)u"yr", CompoundPeriod(Day(365), Hour(6)))
-        @test isapprox(1.0u"yr", CompoundPeriod(Day(365), Hour(6)), rtol=0)
+        @test isapprox(nextfloat(1.0)u"yr", CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)))
+        @test isapprox(1.0u"yr", CompoundPeriod(Day(365), Hour(5), Minute(49), Second(12)), rtol=0)
         @test isapprox(2u"s", CompoundPeriod(Second(2), Millisecond(500)), atol=1u"s")
         @test isapprox(CompoundPeriod(Second(2), Millisecond(500)), 2u"s", atol=CompoundPeriod(Second(1)))
         @test isapprox(CompoundPeriod(Second(2), Millisecond(500)), 2u"s", rtol=0.5)

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -206,6 +206,7 @@
             @test u"μs"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Rational{Int64}(31_556_952_000_000,1)u"μs"
             @test uconvert(u"ns", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Int64(31_556_952_000_000_000)u"ns"
             @test u"ns"(CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12))) === Int64(31_556_952_000_000_000)u"ns"
+            @test uconvert(u"ms", 1u"yr") == (Dates.toms(Year(1)))u"ms"  # Compare to Dates stdlib value of a year
             @test uconvert(u"ps", CompoundPeriod(Week(1),Hour(-1))) === Int64(601_200_000_000_000_000)u"ps"
             @test u"ps"(CompoundPeriod(Week(1),Hour(-1))) === Int64(601_200_000_000_000_000)u"ps"
             @test_throws DimensionError uconvert(u"m", CompoundPeriod(Day(365),Hour(5),Minute(49),Second(12)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,7 +197,7 @@ end
             @test 1minute == 60s
             @test 1hr == 60minute
             @test 1d == 24hr
-            @test 1yr == 365.25d
+            @test 1yr == 365.2425d
             @test 1J == 1kg*m^2/s^2
             @test typeof(1cm)(1m) === 100cm
             @test (3V+4V*im) != (3m+4m*im)


### PR DESCRIPTION
Specify Unitful's year unit to be 365.2425 days.

This is the true average number of days in the Gregorian year, every year that is exactly divisible by four is a leap year, except for years that are exactly divisible by 100, but these centurial years are leap years, if they are exactly divisible by 400.

See [`Dates.isleapyear`](https://github.com/JuliaLang/julia/blob/00739173/stdlib/Dates/src/types.jl#L206) and [`Dates.days(::Year)`](https://github.com/JuliaLang/julia/blob/00739173/stdlib/Dates/src/periods.jl#L465).

This is a suggested change in the interest of correctness, but it likely doesn't make much of a difference to most people!

See also #288.