### PR TITLE
Define unit(::Any)m unit(::Funciton) and add a type restriction to unit(::Type{Union{Missing,T}})

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -139,9 +139,11 @@ julia> unit(1.0) == NoUnits
 true
 ```
 """
+@inline unit(x::Any) = NoUnits # In general, things do not have units.
 @inline unit(x::Number) = NoUnits
 @inline unit(x::Type{T}) where {T <: Number} = NoUnits
-@inline unit(x::Type{Union{Missing, T}}) where T = unit(T)
+@inline unit(x::Function) = NoUnits # Functions do not have units. Function values might.
+@inline unit(x::Type{Union{Missing, T}}) where { T <: Number } = unit(T) # Type restriction required here for T, or might result in infinite recursion.
 @inline unit(x::Type{Missing}) = missing
 @inline unit(x::Missing) = missing
 


### PR DESCRIPTION


This is to resolve errors with uncluding units into FiniteDifferences.jl. See https://github.com/JuliaDiff/FiniteDifferences.jl/pull/244 for details.

Tests for Units.jl need to be updated, if this is to be accepted. The totalness of unit introduced via `unit(::Any)` might be a bit controversial, but I don't think that should be a problem. In general, things don't have units. Only Numbers do.

Closes #806.