### PR TITLE
Make docs build less platform-dependent

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - run: sudo apt install -y fonts-freefont-ttf
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - run: sudo apt install -y ghostscript fonts-freefont-ttf
+      - run: sudo apt install -y fonts-freefont-ttf
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Ghostscript_jll = "61579ee1-b43e-5ca0-a5da-69d92c66a64b"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Ghostscript_jll = "61579ee1-b43e-5ca0-a5da-69d92c66a64b"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Fontconfig = "186bb1d3-e1f7-5a2c-a377-96d770f13627"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
@@ -16,3 +17,4 @@ Unitful = {path = ".."}
 Documenter = "1"
 Latexify = "0.16.9"
 Plots = "1"
+Fontconfig = "0.4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -15,6 +15,6 @@ Unitful = {path = ".."}
 
 [compat]
 Documenter = "1"
-Latexify = "0.16.9"
+Latexify = "0.16.10"
 Plots = "1"
 Fontconfig = "0.4"

--- a/docs/generate_latex_images.jl
+++ b/docs/generate_latex_images.jl
@@ -1,4 +1,5 @@
-using LaTeXStrings, Unitful, Latexify, tectonic_jll
+using LaTeXStrings, Unitful, Latexify
+import tectonic_jll, Ghostscript_jll # needed for Latexify extensions that help render
 
 commands = [
     :(latexify(612.2u"nm")),

--- a/docs/generate_latex_images.jl
+++ b/docs/generate_latex_images.jl
@@ -32,7 +32,7 @@ ltab1 = LaTeXString("""
     \\color{black}
 """ * ltab1)
 
-render(ltab1, MIME("image/png"); use_tectonic=true,
+render(ltab1, MIME("image/png"); use_tectonic=true, open=false,
     name=(@__DIR__)*"/src/assets/latex-examples", 
     packages=["booktabs", "color", "siunitx", "fontspec"], 
     documentclass=("standalone"))
@@ -150,7 +150,7 @@ ltab2 = LaTeXString(
     \\color{black}
     """ * ltab2)
 
-render(ltab2, MIME("image/png"); use_tectonic=true, 
+render(ltab2, MIME("image/png"); use_tectonic=true, open=false,
     tectonic_flags=`-Z continue-on-errors`,
     name=(@__DIR__)*"/src/assets/latex-allunits", 
     packages=["booktabs", "color", "siunitx", "fontspec"], 

--- a/docs/generate_latex_images.jl
+++ b/docs/generate_latex_images.jl
@@ -1,5 +1,5 @@
 using LaTeXStrings, Unitful, Latexify
-import tectonic_jll, Ghostscript_jll # needed for Latexify extensions that help render
+import tectonic_jll # needed for lightweight LaTeX render
 
 commands = [
     :(latexify(612.2u"nm")),

--- a/docs/generate_latex_images.jl
+++ b/docs/generate_latex_images.jl
@@ -1,5 +1,10 @@
 using LaTeXStrings, Unitful, Latexify
 import tectonic_jll # needed for lightweight LaTeX render
+using Fontconfig: format, match, Pattern
+
+# Since the docs can get built on different systems, we need to find a locally installed 
+# monospaced font that has enough Unicode coverage to handle π
+monofont = format(match(Pattern(spacing=100, charset="3c0")), "%{family}")
 
 commands = [
     :(latexify(612.2u"nm")),
@@ -20,11 +25,16 @@ end
 ltab1 = latextabular(tab1, adjustment=:l, transpose=true, latex=false, booktabs=true, 
     head=["julia", "\\LaTeX", "Result"])
 # Setting an explicit white background color results in transparent PDF, so go offwhite.
-ltab1 = LaTeXString("\\definecolor{offwhite}{rgb}{0.999,0.999,0.999}\n\\pagecolor{offwhite}\n\\color{black}\n" * ltab1)
+ltab1 = LaTeXString("""
+    \\setmonofont{$monofont}
+    \\definecolor{offwhite}{rgb}{0.999,0.999,0.999}
+    \\pagecolor{offwhite}
+    \\color{black}
+""" * ltab1)
 
 render(ltab1, MIME("image/png"); use_tectonic=true,
     name=(@__DIR__)*"/src/assets/latex-examples", 
-    packages=["booktabs", "color", "siunitx"], 
+    packages=["booktabs", "color", "siunitx", "fontspec"], 
     documentclass=("standalone"))
 
 functions = [
@@ -134,8 +144,7 @@ ltab2 = latextabular(tab2, adjustment=:l, transpose=true, latex=false, booktabs=
 # Set background to not-quite-white so it doesn't get treated as transparent
 ltab2 = LaTeXString(
     """
-    \\setmainfont{FreeSerif}
-    \\setmonofont{FreeMono}
+    \\setmonofont{$monofont}
     \\definecolor{offwhite}{rgb}{0.999,0.999,0.999}
     \\pagecolor{offwhite}
     \\color{black}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,30 +4,31 @@ using Documenter, Unitful, Dates
 include("generate_latex_images.jl")
 
 DocMeta.setdocmeta!(Unitful, :DocTestSetup, :(using Unitful))
-
-makedocs(
-    sitename = "Unitful.jl",
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
-    warnonly = [:missing_docs],
-    modules = [Unitful],
-    workdir = joinpath(@__DIR__, ".."),
-    pages = [
-        "Home" => "index.md"
-        "Highlighted features" => "highlights.md"
-        "Types" => "types.md"
-        "Defining new units" => "newunits.md"
-        "Conversion/promotion" => "conversion.md"
-        "Manipulating units" => "manipulations.md"
-        "How units are displayed" => "display.md"
-        "Logarithmic scales" => "logarithm.md"
-        "Temperature scales" => "temperature.md"
-        "Interoperability with `Dates`" => "dates.md"
-        "Latexifying units" => "latexify.md"
-        "Extending Unitful" => "extending.md"
-        "Troubleshooting" => "trouble.md"
-        "Pre-defined dimensions, units, and constants" => "defaultunits.md"
-        "License" => "LICENSE.md"
-    ]
-)
+withenv("UNITFUL_FANCY_EXPONENTS" => "false") do
+    makedocs(
+        sitename = "Unitful.jl",
+        format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
+        warnonly = [:missing_docs],
+        modules = [Unitful],
+        workdir = joinpath(@__DIR__, ".."),
+        pages = [
+            "Home" => "index.md"
+            "Highlighted features" => "highlights.md"
+            "Types" => "types.md"
+            "Defining new units" => "newunits.md"
+            "Conversion/promotion" => "conversion.md"
+            "Manipulating units" => "manipulations.md"
+            "How units are displayed" => "display.md"
+            "Logarithmic scales" => "logarithm.md"
+            "Temperature scales" => "temperature.md"
+            "Interoperability with `Dates`" => "dates.md"
+            "Latexifying units" => "latexify.md"
+            "Extending Unitful" => "extending.md"
+            "Troubleshooting" => "trouble.md"
+            "Pre-defined dimensions, units, and constants" => "defaultunits.md"
+            "License" => "LICENSE.md"
+        ]
+    )
+end
 
 deploydocs(repo = "github.com/JuliaPhysics/Unitful.jl.git")


### PR DESCRIPTION
~This should make it easier to build docs locally cross-platform, making explicit a Ghostscript_jll dependency that wasn't obvious in #795 . Depends on https://github.com/korsbo/Latexify.jl/pull/344 getting merged and released (hi @gustaphe), and Latexify compat should get bumped accordingly in `docs/project.toml`.~

Existing caveats:
- ~Still depends on system having the `FreeSerif` and `FreeMono` fonts installed. The default font in tectonic for `Latexify.render` was not sufficiently clear for my tastes. Fortunately, these fonts might be installed by default by some unix packages, and if not can be installed for free with `sudo apt install fonts-freefont-ttf`, or from places online it seems.~
- Until https://github.com/JuliaPlots/Plots.jl/pull/5174 merges, the docs can only be built once per Julia session. (The docs build loads Plots, which loads UnitfulLatexify, which seems to overwrite some of the Latexify recipes and generate incorrect LaTeX on the next build.)

That second can possibly be assuaged (for the meantime) by adjusting `docs/make.jl` to check if the images already exist:
```julia
if !isfile((@__DIR__) * "/src/assets/latex-examples.png") || !isfile((@__DIR__) * "/src/assets/latex-allunits.png")
    @info "Generating latex images for documentation"
    include("generate_latex_images.jl")
end
```
where currently the latex images are generated either way.