### PR TITLE
Swap `\;` for `\,` in LatexifyExt and matching tests

### DIFF
--- a/ext/LatexifyExt.jl
+++ b/ext/LatexifyExt.jl
@@ -193,7 +193,7 @@ function _transform(q::AbstractQuantity, ::AbstractNumberFormatter)
     Expr(
         :latexifymerge,
         NakedNumber(q.val),
-        has_unit_spacing(unit(q)) ? "\\;" : nothing,
+        has_unit_spacing(unit(q)) ? "\\," : nothing,
         NakedUnits(unit(q)),
     )
 end
@@ -243,7 +243,7 @@ end
         )
     end
     env --> :inline
-    return Expr(:latexifymerge, q.val, "\\;\\mathrm{", unitnames[(:mathrm, unitname)], "}")
+    return Expr(:latexifymerge, q.val, "\\,\\mathrm{", unitnames[(:mathrm, unitname)], "}")
 end
 
 # arrays ------------------------- 
@@ -253,7 +253,7 @@ end
     # Array of quantities with the same unit
     env --> :equation
     return Expr(
-        :latexifymerge, ustrip.(a), has_unit_spacing(first(a)) ? "\\;" : "", unit(first(a))
+        :latexifymerge, ustrip.(a), has_unit_spacing(first(a)) ? "\\," : "", unit(first(a))
     )
 end
 

--- a/ext/LatexifyExt.jl
+++ b/ext/LatexifyExt.jl
@@ -253,7 +253,7 @@ end
     # Array of quantities with the same unit
     env --> :equation
     return Expr(
-        :latexifymerge, ustrip.(a), unit(first(a))
+        :latexifymerge, ustrip.(a), has_unit_spacing(first(a)) ? "\\," : "", unit(first(a))
     )
 end
 

--- a/ext/LatexifyExt.jl
+++ b/ext/LatexifyExt.jl
@@ -253,7 +253,7 @@ end
     # Array of quantities with the same unit
     env --> :equation
     return Expr(
-        :latexifymerge, ustrip.(a), has_unit_spacing(first(a)) ? "\\," : "", unit(first(a))
+        :latexifymerge, ustrip.(a), unit(first(a))
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1793,7 +1793,7 @@ end
     )
     unitfullatexifytest(
         24.7e9u"Gm/s^2",
-        raw"$2.47 \cdot 10^{10}\;\mathrm{Gm}\,\mathrm{s}^{-2}$",
+        raw"$2.47 \cdot 10^{10}\,\mathrm{Gm}\,\mathrm{s}^{-2}$",
         raw"\qty{2.47e10}{\giga\meter\per\second\tothe{2}}",
         raw"\qty{2.47e10}{Gm.s^{-2}}",
     )
@@ -1801,7 +1801,7 @@ end
         u"percent", raw"$\mathrm{\%}$", raw"\unit{\percent}", raw"\unit{\%}"
     )
     unitfullatexifytest(
-        2u"°C", raw"$2\;\mathrm{^\circ C}$", raw"\qty{2}{\celsius}", raw"\qty{2}{\celsius}"
+        2u"°C", raw"$2\,\mathrm{^\circ C}$", raw"\qty{2}{\celsius}", raw"\qty{2}{\celsius}"
     )
     unitfullatexifytest(
         1u"°", raw"$1\mathrm{^{\circ}}$", raw"\qty{1}{\degree}", raw"\qty{1}{\degree}"
@@ -1816,7 +1816,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\;\mathrm{m}
+        \right]\,\mathrm{m}
         \end{equation}
         """,
         raw"""
@@ -1827,7 +1827,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\;\unit{\meter}
+        \right]\,\unit{\meter}
         \end{equation}
         """,
         raw"""
@@ -1838,7 +1838,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\;\unit{m}
+        \right]\,\unit{m}
         \end{equation}
         """,
     )
@@ -1851,7 +1851,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\;\mathrm{m}
+        \right]\,\mathrm{m}
         \end{equation}
         """,
         raw"\qtylist{1;2;3}{\meter}",
@@ -1859,7 +1859,7 @@ end
     )
 
     @test latexify(24.7e9u"Gm/s^2"; fmt="%.1e") ==
-        L"$2.5e+10\;\mathrm{Gm}\,\mathrm{s}^{-2}$"
+        L"$2.5e+10\,\mathrm{Gm}\,\mathrm{s}^{-2}$"
     @test latexify(5.9722e24u"kg"; fmt=SiunitxNumberFormatter(version=2)) ==
         raw"\SI{5.9722e24}{\kilo\gram}"
     @test latexify(u"eV"; fmt=SiunitxNumberFormatter(version=2)) == raw"\si{\electronvolt}"
@@ -1868,16 +1868,16 @@ end
 @testset "permode" begin
     p = 5u"m^3*s^2/H/kg^4"
     @test latexify(p) == LaTeXString(
-        raw"$5\;\mathrm{m}^{3}\,\mathrm{s}^{2}\,\mathrm{kg}^{-4}\,\mathrm{H}^{-1}$"
+        raw"$5\,\mathrm{m}^{3}\,\mathrm{s}^{2}\,\mathrm{kg}^{-4}\,\mathrm{H}^{-1}$"
     )
     @test latexify(p; permode=:power) == LaTeXString(
-        raw"$5\;\mathrm{m}^{3}\,\mathrm{s}^{2}\,\mathrm{kg}^{-4}\,\mathrm{H}^{-1}$"
+        raw"$5\,\mathrm{m}^{3}\,\mathrm{s}^{2}\,\mathrm{kg}^{-4}\,\mathrm{H}^{-1}$"
     )
     @test latexify(p; permode=:slash) == LaTeXString(
-        raw"$5\;\mathrm{m}^{3}\,\mathrm{s}^{2}\,/\,\mathrm{kg}^{4}\,\mathrm{H}$"
+        raw"$5\,\mathrm{m}^{3}\,\mathrm{s}^{2}\,/\,\mathrm{kg}^{4}\,\mathrm{H}$"
     )
     @test latexify(p; permode=:frac) == LaTeXString(
-        raw"$5\;\frac{\mathrm{m}^{3}\,\mathrm{s}^{2}}{\mathrm{kg}^{4}\,\mathrm{H}}$"
+        raw"$5\,\frac{\mathrm{m}^{3}\,\mathrm{s}^{2}}{\mathrm{kg}^{4}\,\mathrm{H}}$"
     )
     @test latexify(p; permode=:frac, fmt=SiunitxNumberFormatter()) ==
         latexify(p; fmt=SiunitxNumberFormatter())
@@ -1899,7 +1899,7 @@ end
 
 @testset "Parentheses" begin
     @test @latexify($(3u"mm")^2 - 4 * $(2u"mm^2")) ==
-        raw"$\left( 3\;\mathrm{mm} \right)^{2} - 4 \cdot 2\;\mathrm{mm}^{2}$"
+        raw"$\left( 3\,\mathrm{mm} \right)^{2} - 4 \cdot 2\,\mathrm{mm}^{2}$"
 end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1816,7 +1816,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\,\mathrm{m}
+        \right]\mathrm{m}
         \end{equation}
         """,
         raw"""
@@ -1827,7 +1827,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\,\unit{\meter}
+        \right]\unit{\meter}
         \end{equation}
         """,
         raw"""
@@ -1838,7 +1838,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\,\unit{m}
+        \right]\unit{m}
         \end{equation}
         """,
     )
@@ -1851,7 +1851,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\,\mathrm{m}
+        \right]\mathrm{m}
         \end{equation}
         """,
         raw"\qtylist{1;2;3}{\meter}",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1816,7 +1816,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\mathrm{m}
+        \right]\,\mathrm{m}
         \end{equation}
         """,
         raw"""
@@ -1827,7 +1827,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\unit{\meter}
+        \right]\,\unit{\meter}
         \end{equation}
         """,
         raw"""
@@ -1838,7 +1838,7 @@ end
         \num{2} \\
         \num{3} \\
         \end{array}
-        \right]\unit{m}
+        \right]\,\unit{m}
         \end{equation}
         """,
     )
@@ -1851,7 +1851,7 @@ end
         2 \\
         3 \\
         \end{array}
-        \right]\mathrm{m}
+        \right]\,\mathrm{m}
         \end{equation}
         """,
         raw"\qtylist{1;2;3}{\meter}",


### PR DESCRIPTION
As briefly discussed in https://github.com/JuliaPhysics/Unitful.jl/pull/795#discussion_r2311799069, it's marginally more appealing to use a thin space (`\,`) than the wider space (`\;`)  between the number and unit of a quantity. This is also the default behavior in LaTeX's siunitx. 

This PR makes that change (fortunately a two-character change), as well as updating the corresponding tests.
Current master: 
<img width="225" height="160" alt="image" src="https://github.com/user-attachments/assets/db9ef8bd-fa48-438d-a6ef-92df13c414a3" />

This PR:
<img width="234" height="160" alt="image" src="https://github.com/user-attachments/assets/75e6d4d1-043e-461a-8a2d-6b40f8e2bb7a" />


The aspect which could depend on taste is that I also removed the spacing between an array and its unit, which seems to visually match the regular quantity spacing. 

For arrays, options are:
With `\,` (~third option~ this PR): (`\begin{equation}
\left[
\begin{array}{c}
1 \\
2 \\
3 \\
\end{array}
\right]\,\mathrm{m}
\end{equation}`)
<img width="251" height="228" alt="image" src="https://github.com/user-attachments/assets/5c0f28ba-a8db-438c-bf6f-06a1a87ae788" />
With `\;` (current master):
<img width="254" height="228" alt="image" src="https://github.com/user-attachments/assets/5cacc1e1-7b35-4062-a922-352b784bff94" />
With no extra spacing at all (~this PR~ former version of this PR): (`\begin{equation}
\left[
\begin{array}{c}
1 \\
2 \\
3 \\
\end{array}
\right]\mathrm{m}
\end{equation}`)
<img width="301" height="228" alt="image" src="https://github.com/user-attachments/assets/f6c060af-7f5b-4fe2-83fa-db32b1190ad4" />

The one caveat I see to removing the space between array and unit is that, formally, the space should be left out when the unit is degrees, and so this puts other units at the same separation as degrees (instead of having an extra space).